### PR TITLE
public contract of Source.Initialize has been separated from the internal contract

### DIFF
--- a/Flaky.Benchmark/Benchmarks/FilterWorkload.cs
+++ b/Flaky.Benchmark/Benchmarks/FilterWorkload.cs
@@ -25,7 +25,7 @@ namespace Flaky.Benchmark
 
 			contextController = new ContextController(44100, 120, new Configuration());
 
-			source.Initialize(new Context(contextController));
+			source.Initialize(null, new Context(contextController));
 		}
 
 		[Benchmark]

--- a/Flaky.Benchmark/Benchmarks/FourierWorkload.cs
+++ b/Flaky.Benchmark/Benchmarks/FourierWorkload.cs
@@ -25,7 +25,7 @@ namespace Flaky.Benchmark
 
 			contextController = new ContextController(44100, 120, new Configuration());
 
-			source.Initialize(new Context(contextController));
+			source.Initialize(null, new Context(contextController));
 		}
 
 		[Benchmark]

--- a/Flaky.Benchmark/Benchmarks/StandardWorkload.cs
+++ b/Flaky.Benchmark/Benchmarks/StandardWorkload.cs
@@ -23,7 +23,7 @@ namespace Flaky.Benchmark
 
 			contextController = new ContextController(44100, 120, new Configuration());
 
-			source.Initialize(new Context(contextController));
+			source.Initialize(null, new Context(contextController));
 		}
 
 		[Benchmark]

--- a/Flaky.Core/Core/Channel.cs
+++ b/Flaky.Core/Core/Channel.cs
@@ -49,7 +49,7 @@ namespace Flaky
 
 			var source = player.CreateSource();
 			codeVersion++;
-			source.Initialize(new Context(controller, codeVersion));
+			source.Initialize(null, new Context(controller, codeVersion));
 			sourceToDispose = this.source;
 			this.source = source;
 		}

--- a/Flaky.Interfaces/Public/ISource.cs
+++ b/Flaky.Interfaces/Public/ISource.cs
@@ -15,6 +15,6 @@ namespace Flaky
 	public interface ISource : IDisposable
 	{
 		Vector2 Play(IContext context);
-		void Initialize(IContext context);
+		void Initialize(ISource parent, IContext context);
 	}
 }

--- a/Flaky.Sources/Sources/Basic/Constant.cs
+++ b/Flaky.Sources/Sources/Basic/Constant.cs
@@ -21,7 +21,7 @@ namespace Flaky
 			return new Vector2(value, value);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			// do nothing
 		}

--- a/Flaky.Sources/Sources/Basic/Difference.cs
+++ b/Flaky.Sources/Sources/Basic/Difference.cs
@@ -26,7 +26,7 @@ namespace Flaky
 			return aValue - bValue;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, a, b);
 		}

--- a/Flaky.Sources/Sources/Basic/Hold.cs
+++ b/Flaky.Sources/Sources/Basic/Hold.cs
@@ -23,7 +23,7 @@ namespace Flaky
 
 		public Hold(string id) : base(id) { }
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 		}

--- a/Flaky.Sources/Sources/Basic/Multiply.cs
+++ b/Flaky.Sources/Sources/Basic/Multiply.cs
@@ -26,7 +26,7 @@ namespace Flaky
 			return aValue * bValue;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, a, b);
 		}

--- a/Flaky.Sources/Sources/Basic/Sum.cs
+++ b/Flaky.Sources/Sources/Basic/Sum.cs
@@ -26,7 +26,7 @@ namespace Flaky
 			return aValue + bValue;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, a, b);
 		}

--- a/Flaky.Sources/Sources/Effects/Chorus.cs
+++ b/Flaky.Sources/Sources/Effects/Chorus.cs
@@ -98,7 +98,7 @@ namespace Flaky
 
 		internal Chr(string id) : base(id) { }
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			state.Initialize(context);

--- a/Flaky.Sources/Sources/Effects/Delay.cs
+++ b/Flaky.Sources/Sources/Effects/Delay.cs
@@ -102,7 +102,7 @@ namespace Flaky
 			return writePosition;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 

--- a/Flaky.Sources/Sources/Effects/Filter/MultiPoleFilter.cs
+++ b/Flaky.Sources/Sources/Effects/Filter/MultiPoleFilter.cs
@@ -29,7 +29,7 @@ namespace Flaky
 
 		protected abstract Source CreateFilterChain(Source input, Source cutoff, string id);
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, cutoff, source, filterChain, feedbackChain, resonance);
 		}

--- a/Flaky.Sources/Sources/Effects/Filter/OnePoleFilter.cs
+++ b/Flaky.Sources/Sources/Effects/Filter/OnePoleFilter.cs
@@ -28,7 +28,7 @@ namespace Flaky
 			this.cutoff = cutoff;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			Initialize(context, source, cutoff);

--- a/Flaky.Sources/Sources/Effects/Fourier/Fourier.cs
+++ b/Flaky.Sources/Sources/Effects/Fourier/Fourier.cs
@@ -216,7 +216,7 @@ namespace Flaky
 			return outputSample;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			state.Initialize(effect);

--- a/Flaky.Sources/Sources/Effects/MatrixVerb.cs
+++ b/Flaky.Sources/Sources/Effects/MatrixVerb.cs
@@ -26,16 +26,15 @@ namespace Flaky
 			this.viscosity = viscosity;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
-			source.Initialize(context);
-			viscosity.Initialize(context);
+			Initialize(context, source, viscosity);
 		}
 
 		public override void Dispose()
-        {
-            Dispose(source, viscosity);
-        }
+		{
+			Dispose(source, viscosity);
+		}
 
 		protected override Vector2 NextSample(IContext context)
 		{

--- a/Flaky.Sources/Sources/Effects/Overdrive.cs
+++ b/Flaky.Sources/Sources/Effects/Overdrive.cs
@@ -21,7 +21,7 @@ namespace Flaky
 			this.hpnoise = new OnePoleHPFilter(new Noise(), 1, $"{id}_hpnoise") * 0.3f;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, source, overdrive, lpnoise, hpnoise);
 		}

--- a/Flaky.Sources/Sources/Effects/Pan.cs
+++ b/Flaky.Sources/Sources/Effects/Pan.cs
@@ -42,7 +42,7 @@ namespace Flaky
 			return Perform(soundValue, positionValue, widthValue);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, sound, position, width);
 		}

--- a/Flaky.Sources/Sources/Effects/Repeater.cs
+++ b/Flaky.Sources/Sources/Effects/Repeater.cs
@@ -95,7 +95,7 @@ namespace Flaky
 			return readPosition;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			state.Initialize(context);

--- a/Flaky.Sources/Sources/Effects/Tape.cs
+++ b/Flaky.Sources/Sources/Effects/Tape.cs
@@ -99,7 +99,7 @@ namespace Flaky
 			Dispose(hpNoiseSum, hpNoiseDiff, source, lfo, hold, analog);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<DetonationState>(context);
 			Initialize(context, hpNoiseSum, hpNoiseDiff, source, lfo, analog, hold);

--- a/Flaky.Sources/Sources/Effects/Transient.cs
+++ b/Flaky.Sources/Sources/Effects/Transient.cs
@@ -143,7 +143,7 @@ namespace Flaky
 			Dispose(source, pitch);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			Initialize(context, trigger, source, pitch);

--- a/Flaky.Sources/Sources/Envelopes/AD.cs
+++ b/Flaky.Sources/Sources/Envelopes/AD.cs
@@ -65,7 +65,7 @@ namespace Flaky
 			return new Vector2(0, 0);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, source, attack, decay);
 		}

--- a/Flaky.Sources/Sources/Envelopes/Fade.cs
+++ b/Flaky.Sources/Sources/Envelopes/Fade.cs
@@ -43,7 +43,7 @@ namespace Flaky
 			}
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 

--- a/Flaky.Sources/Sources/Notes/INoteCollection.cs
+++ b/Flaky.Sources/Sources/Notes/INoteCollection.cs
@@ -7,7 +7,7 @@ namespace Flaky
 	{
 		Note GetNextNote();
 		void Reset();
-		void Initialize(IFlakyContext context);
+		void Initialize(ISource parent, IFlakyContext context);
 
 		void Update(IContext context);
 
@@ -79,7 +79,7 @@ namespace Flaky
 
 		protected abstract int GetNextNoteIndex(int currentNoteIndex);
 
-		public virtual void Initialize(IFlakyContext context)
+		public virtual void Initialize(ISource parent, IFlakyContext context)
 		{
 			state = context.GetOrCreateState<State>(parentId);
 		}

--- a/Flaky.Sources/Sources/Notes/PSeq.cs
+++ b/Flaky.Sources/Sources/Notes/PSeq.cs
@@ -44,7 +44,7 @@ namespace Flaky
 			return currentNotes;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, sequencers);
 		}

--- a/Flaky.Sources/Sources/Notes/RandomWalkNoteCollection.cs
+++ b/Flaky.Sources/Sources/Notes/RandomWalkNoteCollection.cs
@@ -8,11 +8,11 @@ namespace Flaky
 		private readonly ZigguratGaussianDistribution distribution =
 			new ZigguratGaussianDistribution(0, 1);
 
-		private readonly Source deviation;
+		private readonly ISource deviation;
 
 		private float deviationValue = 0;
 
-		public RandomWalkNoteCollection(string sequence, Source deviation, string parentId) : base(sequence, parentId)
+		public RandomWalkNoteCollection(string sequence, ISource deviation, string parentId) : base(sequence, parentId)
 		{
 			this.deviation = deviation ?? throw new ArgumentNullException();
 		}
@@ -40,11 +40,11 @@ namespace Flaky
 			deviationValue = deviation.Play(context).X;
 		}
 
-		public override void Initialize(IFlakyContext context)
+		public override void Initialize(ISource parent, IFlakyContext context)
 		{
-			base.Initialize(context);
+			base.Initialize(parent, context);
 
-			deviation.Initialize(context);
+			deviation.Initialize(parent, context);
 		}
 
 		public override void Dispose()

--- a/Flaky.Sources/Sources/Notes/Sequence.cs
+++ b/Flaky.Sources/Sources/Notes/Sequence.cs
@@ -71,7 +71,7 @@ namespace Flaky
 			length.Play(context);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			base.Initialize(context);
 
@@ -174,13 +174,13 @@ namespace Flaky
 
 		internal abstract bool NextNoteRequired(IContext context);
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, resetSource);
 
 			state = GetOrCreate<State>(context);
 
-			noteCollection.Initialize((IFlakyContext)context);
+			noteCollection.Initialize(this, (IFlakyContext)context);
 		}
 
 		public override void Dispose()

--- a/Flaky.Sources/Sources/Notes/SequenceAggregator.cs
+++ b/Flaky.Sources/Sources/Notes/SequenceAggregator.cs
@@ -69,7 +69,7 @@ namespace Flaky
 			return state.chord[voiceNumber];
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			if (!initialized)
 			{
@@ -102,7 +102,7 @@ namespace Flaky
 				return aggregator.GetNote(context, voiceNumber);
 			}
 
-			public override void Initialize(IContext context)
+			protected override void Initialize(IContext context)
 			{
 				aggregator.Initialize(context);
 			}

--- a/Flaky.Sources/Sources/Notes/SequenceDelay.cs
+++ b/Flaky.Sources/Sources/Notes/SequenceDelay.cs
@@ -56,7 +56,7 @@ namespace Flaky
 			return state.CurrentNote;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			state.Initialize(delay);

--- a/Flaky.Sources/Sources/Notes/SequenceRepeater.cs
+++ b/Flaky.Sources/Sources/Notes/SequenceRepeater.cs
@@ -66,7 +66,7 @@ namespace Flaky
 				: sourcePlayingNote;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			this.state = GetOrCreate<State>(context);
 			Initialize(context, mainSource);

--- a/Flaky.Sources/Sources/Notes/SequenceSubsampler.cs
+++ b/Flaky.Sources/Sources/Notes/SequenceSubsampler.cs
@@ -59,7 +59,7 @@ namespace Flaky
 			}
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			Initialize(context, mainSource, probability);

--- a/Flaky.Sources/Sources/Notes/SequenceTranspose.cs
+++ b/Flaky.Sources/Sources/Notes/SequenceTranspose.cs
@@ -49,7 +49,7 @@ namespace Flaky
 			return new PlayingNote(currentNote, mainNote.StartSample);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, mainSource, deltaSource);
 		}

--- a/Flaky.Sources/Sources/Source.cs
+++ b/Flaky.Sources/Sources/Source.cs
@@ -41,7 +41,12 @@ namespace Flaky
 
 		protected abstract Vector2 NextSample(IContext context);
 
-		public abstract void Initialize(IContext context);
+		public void Initialize(ISource parent, IContext context)
+		{
+			Initialize(context);
+		}
+
+		protected abstract void Initialize(IContext context);
 
 		protected TState GetOrCreate<TState>(IContext context) where TState : class, new()
 		{
@@ -58,7 +63,7 @@ namespace Flaky
 			foreach (var source in sources)
 			{
 				if (source != null)
-					source.Initialize(context);
+					source.Initialize(this, context);
 			}
 		}
 

--- a/Flaky.Sources/Sources/Utility/Analog.cs
+++ b/Flaky.Sources/Sources/Utility/Analog.cs
@@ -82,7 +82,7 @@ namespace Flaky
 			this.input = input;
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			Initialize(context, input);

--- a/Flaky.Sources/Sources/Utility/Recorder.cs
+++ b/Flaky.Sources/Sources/Utility/Recorder.cs
@@ -59,7 +59,7 @@ namespace Flaky
 			Dispose(sources);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			Initialize(context, sources);

--- a/Flaky.Sources/Sources/Waveform/DoublePendulum.cs
+++ b/Flaky.Sources/Sources/Waveform/DoublePendulum.cs
@@ -105,7 +105,7 @@ namespace Flaky
 			return new Vector2(output, output);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Initialize(context, l1Source, l2Source, m1Source, m2Source, gSource);
 		}

--- a/Flaky.Sources/Sources/Waveform/DrumRack.cs
+++ b/Flaky.Sources/Sources/Waveform/DrumRack.cs
@@ -39,7 +39,7 @@ namespace Flaky
 			return result ?? new Vector2(0, 0);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			var factory = Get<IWaveReaderFactory>(context);
 

--- a/Flaky.Sources/Sources/Waveform/Looper.cs
+++ b/Flaky.Sources/Sources/Waveform/Looper.cs
@@ -37,7 +37,7 @@ namespace Flaky
 			return result ?? new Vector2(0, 0);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			var factory = Get<IWaveReaderFactory>(context);

--- a/Flaky.Sources/Sources/Waveform/Metronome.cs
+++ b/Flaky.Sources/Sources/Waveform/Metronome.cs
@@ -9,7 +9,7 @@ namespace Flaky
 {
 	public class Met : Source
 	{
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 		}
 

--- a/Flaky.Sources/Sources/Waveform/Noise.cs
+++ b/Flaky.Sources/Sources/Waveform/Noise.cs
@@ -11,7 +11,7 @@ namespace Flaky
 	{
 		private static Random random = new Random();
 
-		public override void Initialize(IContext context) { }
+		protected override void Initialize(IContext context) { }
 
 		public override void Dispose() { }
 

--- a/Flaky.Sources/Sources/Waveform/Osc.cs
+++ b/Flaky.Sources/Sources/Waveform/Osc.cs
@@ -74,7 +74,7 @@ namespace Flaky
 			return new Vector2(value, value);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			Initialize(context, Frequency, Amplitude);

--- a/Flaky.Sources/Sources/Waveform/SampleAndHold.cs
+++ b/Flaky.Sources/Sources/Waveform/SampleAndHold.cs
@@ -72,7 +72,7 @@ namespace Flaky
 			Dispose(trigger, noteTrigger, source);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			Initialize(context, trigger, noteTrigger, source);

--- a/Flaky.Sources/Sources/Waveform/Sampler.cs
+++ b/Flaky.Sources/Sources/Waveform/Sampler.cs
@@ -50,7 +50,7 @@ namespace Flaky
 			return result ?? new Vector2(0, 0);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			var factory = Get<IWaveReaderFactory>(context);

--- a/Flaky.Sources/Sources/Waveform/Saw.cs
+++ b/Flaky.Sources/Sources/Waveform/Saw.cs
@@ -62,7 +62,7 @@ namespace Flaky
 			return new Vector2(state.position, state.position);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			Initialize(context, Frequency, Amplitude);

--- a/Flaky.Sources/Sources/Waveform/Sq.cs
+++ b/Flaky.Sources/Sources/Waveform/Sq.cs
@@ -83,7 +83,7 @@ namespace Flaky
 			return new Vector2(result, result);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			Initialize(context, Frequency, Amplitude, PWM);

--- a/Flaky.Sources/Sources/Waveform/ThreeBodiesOscillator.cs
+++ b/Flaky.Sources/Sources/Waveform/ThreeBodiesOscillator.cs
@@ -28,7 +28,7 @@ namespace Flaky
 			Dispose(timeFactor);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			Reset();
 

--- a/Flaky.Sources/Sources/Waveform/WaveTable.cs
+++ b/Flaky.Sources/Sources/Waveform/WaveTable.cs
@@ -95,7 +95,7 @@ namespace Flaky
 			Dispose(selector, pitch);
 		}
 
-		public override void Initialize(IContext context)
+		protected override void Initialize(IContext context)
 		{
 			state = GetOrCreate<State>(context);
 			state.Init(pack, Get<IWaveReaderFactory>(context));

--- a/Flaky.Tests/Sources/Envelopes/ADTests.cs
+++ b/Flaky.Tests/Sources/Envelopes/ADTests.cs
@@ -23,8 +23,8 @@ namespace Flaky.Tests
 
 			var context = new StubContext();
 
-			sequence.Initialize(context);
-			ad.Initialize(context);
+			sequence.Initialize(null, context);
+			ad.Initialize(null, context);
 
 			context.Beat = 0;
 

--- a/Flaky.Tests/Sources/Notes/FixLengthSequenceTests.cs
+++ b/Flaky.Tests/Sources/Notes/FixLengthSequenceTests.cs
@@ -12,7 +12,7 @@ namespace Flaky.Tests
 			var sequence = new FixLengthSequence(noteCollection, 4, false, "id1");
 			var context = new StubContext();
 
-			sequence.Initialize(context);
+			sequence.Initialize(null, context);
 
 			Assert.IsTrue(noteCollection.Initialized);
 		}
@@ -24,7 +24,7 @@ namespace Flaky.Tests
 			var sequence = new FixLengthSequence(noteCollection, 4, false, "id1");
 			var context = new StubContext();
 
-			sequence.Initialize(context);
+			sequence.Initialize(null, context);
 
 			context.Beat = 3;
 
@@ -48,7 +48,7 @@ namespace Flaky.Tests
 			var sequence = new FixLengthSequence(noteCollection, 4, false, "id1");
 			var context = new StubContext();
 
-			sequence.Initialize(context);
+			sequence.Initialize(null, context);
 
 			var notes = new[] {
 				new Note(5),
@@ -92,7 +92,7 @@ namespace Flaky.Tests
 
 			var context = new StubContext();
 
-			sequence.Initialize(context);
+			sequence.Initialize(null, context);
 
 			context.Beat = 0;
 

--- a/Flaky.Tests/Sources/Notes/SequentialNoteCollectionTests.cs
+++ b/Flaky.Tests/Sources/Notes/SequentialNoteCollectionTests.cs
@@ -12,7 +12,7 @@ namespace Flaky.Tests
 			var collection = new SequentialNoteCollection("0-5dd2u", "parent1");
 			var context = new StubContext();
 
-			collection.Initialize(context);
+			collection.Initialize(null, context);
 
 			collection.Update(context);
 			Assert.AreEqual(0, collection.GetNextNote().Number);

--- a/Flaky.Tests/Sources/Notes/StubNoteCollection.cs
+++ b/Flaky.Tests/Sources/Notes/StubNoteCollection.cs
@@ -15,7 +15,7 @@
 			return NextNote;
 		}
 
-		public void Initialize(IFlakyContext context)
+		public void Initialize(ISource parent, IFlakyContext context)
 		{
 			Initialized = true;
 		}

--- a/Flaky.Tests/Sources/Notes/VariableLengthSequenceTests.cs
+++ b/Flaky.Tests/Sources/Notes/VariableLengthSequenceTests.cs
@@ -19,7 +19,7 @@ namespace Flaky.Tests
 			var sequence = new VariableLengthSequence(noteCollection, lengthSource, false, "id1");
 			var context = new StubContext();
 
-			sequence.Initialize(context);
+			sequence.Initialize(null, context);
 
 			var notes = new[] {
 				new Note(5),

--- a/Flaky.Tests/Sources/StubSource.cs
+++ b/Flaky.Tests/Sources/StubSource.cs
@@ -14,7 +14,7 @@ namespace Flaky.Tests
 			Disposed = true;
 		}
 
-		public void Initialize(IContext context)
+		public void Initialize(ISource parent, IContext context)
 		{
 			Initialized = true;
 		}


### PR DESCRIPTION
- one of the performance bottlenecks in Source.Play can be removed now
- will be used to collect sources graph in the future