### PR TITLE
Source.Play reenterability check is more specific now

### DIFF
--- a/Flaky.Sources/Sources/Source.cs
+++ b/Flaky.Sources/Sources/Source.cs
@@ -15,6 +15,8 @@ namespace Flaky
 
 		private Vector2 latestSample;
 		private long latestSampleIndex = -1;
+		private bool initialized = false;
+		private bool hasMultipleParents = false;
 
 		protected Source() { }
 
@@ -25,7 +27,7 @@ namespace Flaky
 
 		public Vector2 Play(IContext context)
 		{
-			if (context.Sample == latestSampleIndex)
+			if (hasMultipleParents && context.Sample == latestSampleIndex)
 				return latestSample;
 
 			var result = NextSample(context);
@@ -33,8 +35,11 @@ namespace Flaky
 			if (float.IsNaN(result.X))
 				return new Vector2(0, 0);
 
-			latestSample = result;
-			latestSampleIndex = context.Sample;
+			if (hasMultipleParents)
+			{
+				latestSample = result;
+				latestSampleIndex = context.Sample;
+			}
 
 			return result;
 		}
@@ -43,6 +48,10 @@ namespace Flaky
 
 		public void Initialize(ISource parent, IContext context)
 		{
+			if (initialized)
+				hasMultipleParents = true;
+
+			initialized = true;
 			Initialize(context);
 		}
 


### PR DESCRIPTION
before optimization:

```
StandardWorkload.StandardWorkloadTest: DefaultJob
Runtime = .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3260.0; GC = Concurrent Workstation
Mean = 311.1447 ms, StdErr = 4.5482 ms (1.46%); N = 99, StdDev = 45.2543 ms
Min = 269.0146 ms, Q1 = 277.1281 ms, Median = 294.4877 ms, Q3 = 337.4861 ms, Max = 402.5665 ms
IQR = 60.3581 ms, LowerFence = 186.5910 ms, UpperFence = 428.0232 ms
ConfidenceInterval = [295.7145 ms; 326.5750 ms] (CI 99.9%), Margin = 15.4303 ms (4.96% of Mean)
Skewness = 0.94, Kurtosis = 2.4, MValue = 4.3
-------------------- Histogram --------------------
[265.534 ms ; 282.654 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[282.654 ms ; 291.672 ms) |
[291.672 ms ; 308.791 ms) | @@@@@@@@@@@@@@@@@@
[308.791 ms ; 329.745 ms) |
[329.745 ms ; 346.864 ms) | @@@@@@@@@@@@@@@@@@
[346.864 ms ; 363.983 ms) |
[363.983 ms ; 381.103 ms) |
[381.103 ms ; 390.280 ms) |
[390.280 ms ; 407.400 ms) | @@@@@@@@@@@@@@@@@
---------------------------------------------------
```

after optimization:

```
StandardWorkload.StandardWorkloadTest: DefaultJob
Runtime = .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3260.0; GC = Concurrent Workstation
Mean = 250.3600 ms, StdErr = 4.1073 ms (1.64%); N = 100, StdDev = 41.0733 ms
Min = 206.9401 ms, Q1 = 219.0288 ms, Median = 230.4844 ms, Q3 = 295.6021 ms, Max = 334.6499 ms
IQR = 76.5733 ms, LowerFence = 104.1688 ms, UpperFence = 410.4621 ms
ConfidenceInterval = [236.4298 ms; 264.2901 ms] (CI 99.9%), Margin = 13.9301 ms (5.56% of Mean)
Skewness = 0.72, Kurtosis = 2.07, MValue = 3.83
-------------------- Histogram --------------------
[205.804 ms ; 221.290 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[221.290 ms ; 239.703 ms) | @@@@@@@@
[239.703 ms ; 255.455 ms) |
[255.455 ms ; 270.941 ms) | @@@@@@@@@@@@@@@@@@
[270.941 ms ; 293.766 ms) |
[293.766 ms ; 309.252 ms) | @@@@@@@@@@@@@@@@@@
[309.252 ms ; 326.212 ms) |
[326.212 ms ; 342.393 ms) | @@@@@@@@
---------------------------------------------------
```