### PR TITLE
 one pole filter optimizations

### DIFF
--- a/Flaky.Sources/Sources/Effects/Filter/OnePoleFilter.cs
+++ b/Flaky.Sources/Sources/Effects/Filter/OnePoleFilter.cs
@@ -90,7 +90,5 @@ namespace Flaky
 		{
 			this.source = mainSource;
 		}
-
-		protected abstract Vector2 GetResult(Vector2 lp, Vector2 hp);
 	}
 }

--- a/Flaky.Sources/Sources/Effects/Filter/OnePoleFilter.cs
+++ b/Flaky.Sources/Sources/Effects/Filter/OnePoleFilter.cs
@@ -9,6 +9,7 @@ namespace Flaky
 		private Source cutoff;
 		private State state;
 		private const int oversampling = 4;
+		private bool isHighPass;
 
 		private class State
 		{
@@ -17,15 +18,17 @@ namespace Flaky
 			public Vector2 latestInputSample;
 		}
 
-		internal OnePoleFilter(Source source, Source cutoff, string id) : base(id)
+		internal OnePoleFilter(Source source, Source cutoff, bool isHighPass, string id) : base(id)
 		{
 			this.source = source;
 			this.cutoff = cutoff;
+			this.isHighPass = isHighPass;
 		}
 
-		internal OnePoleFilter(Source cutoff, string id) : base(id)
+		internal OnePoleFilter(Source cutoff, bool isHighPass, string id) : base(id)
 		{
 			this.cutoff = cutoff;
+			this.isHighPass = isHighPass;
 		}
 
 		protected override void Initialize(IContext context)
@@ -42,39 +45,45 @@ namespace Flaky
 		protected override Vector2 NextSample(IContext context)
 		{
 			var sample = source.Play(context);
-			var cutoffValue = cutoff.Play(context).X;
+			var cutoffValue = cutoff.Play(context).X * 0.25f;
 
 			if (cutoffValue < 0)
 				cutoffValue = 0;
 
-			if (cutoffValue > 1)
-				cutoffValue = 1;
+			if (cutoffValue > 0.25f)
+				cutoffValue = 0.25f;
 
 			var hp = new Vector2(0, 0);
 			var integrator = state.integratorState;
 			var lp = state.integratorState;
-			var s = sample;
 			var latestInput = state.latestInputSample;
 
 			const float oversamplingD = 1 / (float)oversampling;
 
 			for (int i = 1; i <= oversampling; i++)
 			{
-				hp = (s * i + latestInput * (oversampling - i)) * oversamplingD - lp;
+				// lp = (s * i + latestInput * (oversampling - i)) - lp;
+				if (i == 1)
+					hp = sample + latestInput + latestInput + latestInput - lp;
+				else if (i == 2)
+					hp = sample + sample + latestInput + latestInput - lp;
+				else if (i == 3)
+					hp = sample + sample + sample + latestInput - lp;
+				else if (i == 4)
+					hp = sample + sample + sample + sample - lp;
 
-				var input = hp * (cutoffValue * 0.25f);
-				var output = input + integrator;
-
-				integrator = input + output;
-
-				lp = output;
+				lp = hp * cutoffValue + integrator;
+				integrator = hp * cutoffValue + lp;
 			}
 
 			state.latestInputSample = sample;
 			state.lp = lp;
 			state.integratorState = integrator;
 
-			return GetResult(state.lp, hp);
+			if(isHighPass)
+				return hp * oversamplingD;
+			else
+				return lp * oversamplingD;
 		}
 
 		void IPipingSource<Source>.SetMainSource(Source mainSource)

--- a/Flaky.Sources/Sources/Effects/Filter/OnePoleHPFilter.cs
+++ b/Flaky.Sources/Sources/Effects/Filter/OnePoleHPFilter.cs
@@ -7,10 +7,5 @@ namespace Flaky
 		internal OnePoleHPFilter(Source source, Source cutoff, string id) 
 			: base(source, cutoff, true, id) { }
 		internal OnePoleHPFilter(Source cutoff, string id) : base(cutoff, true, id) { }
-
-		protected override Vector2 GetResult(Vector2 lp, Vector2 hp)
-		{
-			return hp;
-		}
 	}
 }

--- a/Flaky.Sources/Sources/Effects/Filter/OnePoleHPFilter.cs
+++ b/Flaky.Sources/Sources/Effects/Filter/OnePoleHPFilter.cs
@@ -4,8 +4,9 @@ namespace Flaky
 {
 	public class OnePoleHPFilter : OnePoleFilter
 	{
-		internal OnePoleHPFilter(Source source, Source cutoff, string id) : base(source, cutoff, id) { }
-		internal OnePoleHPFilter(Source cutoff, string id) : base(cutoff, id) { }
+		internal OnePoleHPFilter(Source source, Source cutoff, string id) 
+			: base(source, cutoff, true, id) { }
+		internal OnePoleHPFilter(Source cutoff, string id) : base(cutoff, true, id) { }
 
 		protected override Vector2 GetResult(Vector2 lp, Vector2 hp)
 		{

--- a/Flaky.Sources/Sources/Effects/Filter/OnePoleLPFilter.cs
+++ b/Flaky.Sources/Sources/Effects/Filter/OnePoleLPFilter.cs
@@ -5,14 +5,9 @@ namespace Flaky
 	public class OnePoleLPFilter : OnePoleFilter
 	{
 		internal OnePoleLPFilter(Source source, Source cutoff, string id) 
-			: base(source, cutoff, true, id) { }
+			: base(source, cutoff, false, id) { }
 
 		internal OnePoleLPFilter(Source cutoff, string id) 
-			: base(cutoff, true, id) { }
-
-		protected override Vector2 GetResult(Vector2 lp, Vector2 hp)
-		{
-			return lp;
-		}
+			: base(cutoff, false, id) { }
 	}
 }

--- a/Flaky.Sources/Sources/Effects/Filter/OnePoleLPFilter.cs
+++ b/Flaky.Sources/Sources/Effects/Filter/OnePoleLPFilter.cs
@@ -4,9 +4,11 @@ namespace Flaky
 {
 	public class OnePoleLPFilter : OnePoleFilter
 	{
-		internal OnePoleLPFilter(Source source, Source cutoff, string id) : base(source, cutoff, id) { }
+		internal OnePoleLPFilter(Source source, Source cutoff, string id) 
+			: base(source, cutoff, true, id) { }
 
-		internal OnePoleLPFilter(Source cutoff, string id) : base(cutoff, id) { }
+		internal OnePoleLPFilter(Source cutoff, string id) 
+			: base(cutoff, true, id) { }
 
 		protected override Vector2 GetResult(Vector2 lp, Vector2 hp)
 		{


### PR DESCRIPTION
filter workload before:

```
             Method |     Mean |     Error |    StdDev |
------------------- |---------:|----------:|----------:|
 FilterWorkloadTest | 33.93 ms | 0.0107 ms | 0.0089 ms |
```

filter workload after:

```
              Method |     Mean |     Error |    StdDev |
------------------- |---------:|----------:|----------:|
 FilterWorkloadTest | 29.76 ms | 0.0273 ms | 0.0242 ms |
```

standard workload before:

```
StandardWorkload.StandardWorkloadTest: DefaultJob
Runtime = .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3260.0; GC = Concurrent Workstation
Mean = 250.3600 ms, StdErr = 4.1073 ms (1.64%); N = 100, StdDev = 41.0733 ms
Min = 206.9401 ms, Q1 = 219.0288 ms, Median = 230.4844 ms, Q3 = 295.6021 ms, Max = 334.6499 ms
IQR = 76.5733 ms, LowerFence = 104.1688 ms, UpperFence = 410.4621 ms
ConfidenceInterval = [236.4298 ms; 264.2901 ms] (CI 99.9%), Margin = 13.9301 ms (5.56% of Mean)
Skewness = 0.72, Kurtosis = 2.07, MValue = 3.83
-------------------- Histogram --------------------
[205.804 ms ; 221.290 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[221.290 ms ; 239.703 ms) | @@@@@@@@
[239.703 ms ; 255.455 ms) |
[255.455 ms ; 270.941 ms) | @@@@@@@@@@@@@@@@@@
[270.941 ms ; 293.766 ms) |
[293.766 ms ; 309.252 ms) | @@@@@@@@@@@@@@@@@@
[309.252 ms ; 326.212 ms) |
[326.212 ms ; 342.393 ms) | @@@@@@@@
---------------------------------------------------
```

standard workload after:

```
StandardWorkload.StandardWorkloadTest: DefaultJob
Runtime = .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3260.0; GC = Concurrent Workstation
Mean = 196.6964 ms, StdErr = 1.0324 ms (0.52%); N = 25, StdDev = 5.1622 ms
Min = 188.5776 ms, Q1 = 192.4465 ms, Median = 198.2948 ms, Q3 = 201.1200 ms, Max = 204.3966 ms
IQR = 8.6735 ms, LowerFence = 179.4362 ms, UpperFence = 214.1302 ms
ConfidenceInterval = [192.8295 ms; 200.5632 ms] (CI 99.9%), Margin = 3.8669 ms (1.97% of Mean)
Skewness = -0.02, Kurtosis = 1.64, MValue = 2
-------------------- Histogram --------------------
[187.808 ms ; 192.759 ms) | @@@@@@
[192.759 ms ; 200.616 ms) | @@@@@@@@@@@@@
[200.616 ms ; 205.941 ms) | @@@@@@
---------------------------------------------------
```